### PR TITLE
Check and add in extra samples to stream

### DIFF
--- a/rtm/waveform.py
+++ b/rtm/waveform.py
@@ -116,6 +116,21 @@ def process_waveforms(st, freqmin, freqmax, envelope=False,
         st_n.normalize()
         streams['normalized'] = st_n
 
+    # Ensure all traces have the same number of values. Only operate on final
+    # entry lof stream dictionary
+    st_out = list(streams.values())[-1]
+    # Find unique number of values in stream
+    u_val, u_ind, u_cts = np.unique(np.array([tr.count() for tr in st_out]),
+                                    return_index=True, return_counts=True)
+    if len(u_val) > 1:
+        # Find the trace with differing numbers of samples
+        min_ind = u_ind[u_cts.argmin()]  #index to trace with lower number
+        npts_add = u_val.max() - u_val.min()    #number of points to add
+        print(f'Adding {npts_add} sample(s) to trace {st_out[min_ind].id}')
+        # add zero data values
+        st_out[min_ind].data = np.hstack([st_out[min_ind].data,
+                                          np.zeros(1, npts_add)])
+
     print('Done')
 
     if plot_steps:

--- a/rtm/waveform.py
+++ b/rtm/waveform.py
@@ -116,13 +116,14 @@ def process_waveforms(st, freqmin, freqmax, envelope=False,
         st_n.normalize()
         streams['normalized'] = st_n
 
-    # Ensure all traces have the same number of values. Only operate on final
-    # entry lof stream dictionary
+    # Ensure all Traces have the same number of values. Only operate on final
+    # entry in Stream dictionary
     st_out = list(streams.values())[-1]
-
     min_starttime = np.min([tr.stats.starttime for tr in st_out])
     max_endtime = np.max([tr.stats.endtime for tr in st_out])
-
+    for tr in st_out:
+        # Use earliest starttime as starttime for all traces
+        tr.stats.starttime = min_starttime
     # Most conservative trim possible - will zero-pad on either end
     st_out.trim(min_starttime, max_endtime, pad=True, fill_value=0)
 
@@ -137,8 +138,6 @@ def process_waveforms(st, freqmin, freqmax, envelope=False,
             fig.tight_layout()
             fig.show()
         print('Done')
-
-    st_out = list(streams.values())[-1]  # Final entry in Stream dictionary
 
     return st_out
 

--- a/rtm/waveform.py
+++ b/rtm/waveform.py
@@ -119,17 +119,12 @@ def process_waveforms(st, freqmin, freqmax, envelope=False,
     # Ensure all traces have the same number of values. Only operate on final
     # entry lof stream dictionary
     st_out = list(streams.values())[-1]
-    # Find unique number of values in stream
-    u_val, u_ind, u_cts = np.unique(np.array([tr.count() for tr in st_out]),
-                                    return_index=True, return_counts=True)
-    if len(u_val) > 1:
-        # Find the trace with differing numbers of samples
-        min_ind = u_ind[u_cts.argmin()]  #index to trace with lower number
-        npts_add = u_val.max() - u_val.min()    #number of points to add
-        print(f'Adding {npts_add} sample(s) to trace {st_out[min_ind].id}')
-        # add zero data values
-        st_out[min_ind].data = np.hstack([st_out[min_ind].data,
-                                          np.zeros(1, npts_add)])
+
+    min_starttime = np.min([tr.stats.starttime for tr in st_out])
+    max_endtime = np.max([tr.stats.endtime for tr in st_out])
+
+    # Most conservative trim possible - will zero-pad on either end
+    st_out.trim(min_starttime, max_endtime, pad=True, fill_value=0)
 
     print('Done')
 


### PR DESCRIPTION
This checks the stream in process_waveforms and adds in any extra samples to ensure all traces in the stream have the same number of samples. It seems like the interpolation will occasionally leave a trace short a sample, which then messes up the grid search. Addresses #29. Not elegant, but I couldn't find an easy way to accomplish this.