### PR TITLE
Plot time slice in x/y coordinates rather than UTM  

### DIFF
--- a/example_local.py
+++ b/example_local.py
@@ -82,7 +82,7 @@ fig_st = plot_st(st, filt=[FREQ_MIN, FREQ_MAX], equal_scale=False,
                  remove_response=True, label_waveforms=True)
 
 fig_slice = plot_time_slice(S, st_proc, label_stations=True, dem=dem,
-                            plot_peak=True)
+                            plot_peak=True, xy_grid=600)
 
 time_max, y_max, x_max, peaks, props = get_peak_coordinates(S, global_max=False,
                                                             height=3, min_time=2,

--- a/example_regional.py
+++ b/example_regional.py
@@ -65,7 +65,7 @@ S = grid_search(processed_st=st_proc, grid=grid, time_method=TIME_METHOD,
 
 from rtm import plot_time_slice, plot_record_section, get_peak_coordinates
 
-fig_slice = plot_time_slice(S, st_proc, label_stations=False, hires=True,
+fig_slice = plot_time_slice(S, st_proc, label_stations=False, hires=False,
                             plot_peak=True)
 
 time_max, y_max, x_max, _, _ = get_peak_coordinates(S, unproject=S.UTM)

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -160,16 +160,6 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
                                  add_colorbar=False, add_labels=False,
                                  zorder=0)
 
-        # Add scalebar
-        SCALEBAR_INC = 100  # [m] Scalebar increment (will be multiple of this)
-        target_length = dem.x_radius / 4
-        bar_length = np.around(target_length / SCALEBAR_INC) * SCALEBAR_INC
-        bar_label = f'{bar_length:g} m'
-        scalebar = AnchoredSizeBar(ax.transData, bar_length, bar_label,
-                                   'lower left', pad=0.3, color='black',
-                                   frameon=True, size_vertical=1, borderpad=1)
-        ax.add_artist(scalebar)
-
         plot_transform = ax.transData
 
         # Mask areas outside of DEM extent

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -43,10 +43,10 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
             DEM from :class:`~rtm.grid.produce_dem` (default: `None`)
         plot_peak (bool): Plot the peak stack function over time as a subplot
             (default: `True`)
-        xy_grid (int): If not `None`, transforms UTM coordinates such that the
-            grid center is at (0, 0) — the plot extent is then given by
-            (-xy_grid, xy_grid) [meters] for easting and northing. Only valid
-            for projected grids
+        xy_grid (int, float, or None): If not `None`, transforms UTM
+            coordinates such that the grid center is at (0, 0) — the plot
+            extent is then given by (-xy_grid, xy_grid) [meters] for easting
+            and northing. Only valid for projected grids
         cont_int (int): Contour interval [m] for plots with DEM data
         annot_int (int): Annotated contour interval [m] for plots with DEM data
             (these contours are thicker and labeled)
@@ -176,7 +176,8 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
         plot_transform = ax.transData
 
         # Mask areas outside of DEM extent
-        dem_slice = dem.sel(x=slice.x, y=slice.y, method='nearest')  # Select subset of DEM that slice occupies
+        # Select subset of DEM that slice occupies
+        dem_slice = dem.sel(x=slice.x, y=slice.y, method='nearest')
         slice.data[np.isnan(dem_slice.data)] = np.nan
 
     if S.UTM:
@@ -236,7 +237,8 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
     ax.legend(h, [handle.get_label() for handle in h], loc='best',
               framealpha=1, borderpad=.3, handletextpad=.3)
 
-    time_round = np.datetime64(slice.time.values + np.timedelta64(500, 'ms'), 's').astype(datetime)  # Nearest second
+    time_round = np.datetime64(slice.time.values + np.timedelta64(500, 'ms'),
+                               's').astype(datetime)  # Nearest second
     title = 'Time: {}'.format(time_round)
 
     if hasattr(S, 'celerity'):

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -228,6 +228,10 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
     if dem is not None:
         ax.set_aspect('equal')
 
+    # crop plot to show just the slice area
+    ax.set_xlim(slice.x.min(), slice.x.max())
+    ax.set_ylim(slice.y.min(), slice.y.max())
+
     ax_pos = ax.get_position()
     cloc = [ax_pos.x1+.02, ax_pos.y0, .02, ax_pos.height]
     cbaxes = fig.add_axes(cloc)

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -118,8 +118,8 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
         print('Converting to x/y grid')
 
         #update dataarrays to x/y coordinates from dem
-        xmin = dem.x.data.min()
-        ymin = dem.y.data.min()
+        xmin = dem.x.data.min() + dem.x_radius
+        ymin = dem.y.data.min() + dem.y_radius
         slice = slice.assign_coords(x=(slice.x.data - xmin))
         slice = slice.assign_coords(y=(slice.y.data - ymin))
         dem = dem.assign_coords(x=(dem.x.data - xmin))

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -207,7 +207,8 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
                     horizontalalignment='left', fontsize=10, color='white',
                     transform=plot_transform, zorder=scatter_zorder,
                     path_effects=[pe.Stroke(linewidth=2, foreground='black'),
-                                  pe.Normal()])
+                                  pe.Normal()],
+                    clip_on=True)
 
     ax.legend(h, [handle.get_label() for handle in h], loc='best',
               framealpha=1, borderpad=.3, handletextpad=.3)

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -113,14 +113,17 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
     slice = S.sel(time=time_to_plot, method='nearest')
 
     #convert UTM grid/etc to x/y coordinates with (0,0) as origin
-    if S.UTM:
-        #update dataarrays to x/y coordinates
-        xmin = slice.x.data.min()
-        ymin = slice.y.data.min()
+    if S.UTM and dem is not None:
+
+        print('Converting to x/y grid')
+
+        #update dataarrays to x/y coordinates from dem
+        xmin = dem.x.data.min()
+        ymin = dem.y.data.min()
         slice = slice.assign_coords(x=(slice.x.data - xmin))
         slice = slice.assign_coords(y=(slice.y.data - ymin))
-        dem = dem.assign_coords(x=(dem.x.data - dem.x.data.min()))
-        dem = dem.assign_coords(y=(dem.y.data - dem.y.data.min()))
+        dem = dem.assign_coords(x=(dem.x.data - xmin))
+        dem = dem.assign_coords(y=(dem.y.data - ymin))
         lon_0 = lon_0 - xmin
         lat_0 = lat_0 - ymin
         x_max = x_max - xmin

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -529,16 +529,23 @@ def _plot_geographic_context(ax, utm, hires=False):
     # coastlines
     else:
         if hires:
-            scale = '10m'
+            gshhs_scale = 'intermediate'
+            lake_scale = '10m'
         else:
-            scale = '50m'
-        land = cfeature.LAND.with_scale(scale)
-        ax.add_feature(land, facecolor=cfeature.COLORS['land'],
-                       edgecolor='black')
+            gshhs_scale = 'low'
+            lake_scale = '50m'
+
+        ax.add_feature(
+            cfeature.GSHHSFeature(scale=gshhs_scale),
+            facecolor=cfeature.COLORS['land'], zorder=0,
+        )
         ax.background_patch.set_facecolor(cfeature.COLORS['water'])
-        lakes = cfeature.LAKES.with_scale(scale)
-        ax.add_feature(lakes, facecolor=cfeature.COLORS['water'],
-                       edgecolor='black', zorder=0)
+        ax.add_feature(
+            cfeature.LAKES.with_scale(lake_scale),
+            facecolor=cfeature.COLORS['water'],
+            edgecolor='black',
+            zorder=0,
+        )
 
 
 # Subclass ConciseDateFormatter (modifies __init__() and set_axis() methods)

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -112,6 +112,23 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
 
     slice = S.sel(time=time_to_plot, method='nearest')
 
+    #convert UTM grid/etc to x/y coordinates with (0,0) as origin
+    if S.UTM:
+        #update dataarrays to x/y coordinates
+        xmin = slice.x.data.min()
+        ymin = slice.y.data.min()
+        slice = slice.assign_coords(x=(slice.x.data - xmin))
+        slice = slice.assign_coords(y=(slice.y.data - ymin))
+        dem = dem.assign_coords(x=(dem.x.data - dem.x.data.min()))
+        dem = dem.assign_coords(y=(dem.y.data - dem.y.data.min()))
+        lon_0 = lon_0 - xmin
+        lat_0 = lat_0 - ymin
+        x_max = x_max - xmin
+        y_max = y_max - ymin
+        for tr in st:
+            tr.stats.longitude = tr.stats.longitude - xmin
+            tr.stats.latitude = tr.stats.latitude - ymin
+
     if dem is None:
         _plot_geographic_context(ax=ax, utm=S.UTM, hires=hires)
         slice_plot_kwargs = dict(ax=ax, alpha=0.5, cmap='viridis',
@@ -136,8 +153,8 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
                               zorder=-1, linewidths=0.7)
         ax.clabel(cs, fontsize=9, fmt='%d', inline=True)  # Actually annotate
 
-        ax.set_xlabel('UTM easting (m)')
-        ax.set_ylabel('UTM northing (m)')
+        ax.set_xlabel('X [m]')
+        ax.set_ylabel('Y [m]')
 
         slice_plot_kwargs = dict(ax=ax, alpha=0.7, cmap='viridis',
                                  add_colorbar=False, add_labels=False,
@@ -179,9 +196,9 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
     # Plot stack maximum
     if S.UTM:
         # UTM formatting
-        label = f'Stack max'
+        label = 'Stack max'
         # Change ticks to plain format for long utm coordinates
-        ax.ticklabel_format(style='plain', useOffset=False)
+        #ax.ticklabel_format(style='plain', useOffset=False)
     else:
         # Lat/lon formatting
         label = f'Stack max\n({y_max:.4f}, {x_max:.4f})'

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -185,10 +185,8 @@ def plot_time_slice(S, processed_st, time_slice=None, label_stations=True,
 
     # Plot stack maximum
     if S.UTM:
-        # UTM formatting
+        # x/y formatting
         label = 'Stack max'
-        # Change ticks to plain format for long utm coordinates
-        #ax.ticklabel_format(style='plain', useOffset=False)
     else:
         # Lat/lon formatting
         label = f'Stack max\n({y_max:.4f}, {x_max:.4f})'


### PR DESCRIPTION
UTM coordinates are more difficult to interpret visually and crowd the x and y axis labels. This pull request modifies the time slice to plot in x/y coordinates based on the DEM extent. There are other ways to do this, but wanted to get something started on it.