### PR TITLE
Some plotting fixes

### DIFF
--- a/rtm/grid.py
+++ b/rtm/grid.py
@@ -144,7 +144,8 @@ def define_grid(lon_0, lat_0, x_radius, y_radius, spacing, projected=False,
         fig, ax = plt.subplots(figsize=(10, 10),
                                subplot_kw=dict(projection=proj))
 
-        _plot_geographic_context(ax=ax, utm=projected)
+        if not projected:
+            _plot_geographic_context(ax=ax)
 
         # Note that trial source locations are at the CENTER of each plotted
         # grid box

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -304,7 +304,7 @@ def plot_record_section(st, origin_time, source_location, plot_celerity=None,
     fig = plt.figure(figsize=(12, 8))
 
     st_edit.plot(fig=fig, type='section', orientation='horizontal',
-                 fillcolors=('black', 'black'))
+                 fillcolors=('black', 'black'), linewidth=0)
 
     ax = fig.axes[0]
 


### PR DESCRIPTION
This PR:
1. fixes a small record section plotting issue, and
2. reconfigures plotting so that cartopy is only used when we're make a regional (Albers) plot. The only thing we lose w/ this is the image tile download and plotting functionality, which seemed to be seldom used since we have a DEM almost always.

Plotting should be more simple now.