### PR TITLE
Add state boundaries, gridlines, and labels using cartopy

### DIFF
--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -539,7 +539,7 @@ def _plot_geographic_context(ax, hires=False):
         scale='50m',
         facecolor='none')
     ax.add_feature(states_provinces, edgecolor='gray')
-    
+    ax.add_feature(cfeature.BORDERS, edgecolor='gray')
     # Add gridlines and labels
     ax.gridlines(draw_labels=["x", "y", "left", "bottom"], linewidth=1, 
                       color='gray', alpha=0.5, linestyle='--')

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -538,9 +538,12 @@ def _plot_geographic_context(ax, hires=False):
         name='admin_1_states_provinces_lines',
         scale='50m',
         facecolor='none')
-
     ax.add_feature(states_provinces, edgecolor='gray')
     
+    # Add gridlines and labels
+    ax.gridlines(draw_labels=["x", "y", "left", "bottom"], linewidth=1, 
+                      color='gray', alpha=0.5, linestyle='--')
+
 
 
 # Subclass ConciseDateFormatter (modifies __init__() and set_axis() methods)

--- a/rtm/plotting.py
+++ b/rtm/plotting.py
@@ -512,7 +512,7 @@ def _plot_geographic_context(ax, hires=False):
     """
 
     # Since unprojected grids have regional/global extent, just show the
-    # coastlines
+    # coastlines and borders
     if hires:
         gshhs_scale = 'intermediate'
         lake_scale = '10m'
@@ -531,6 +531,16 @@ def _plot_geographic_context(ax, hires=False):
         edgecolor='black',
         zorder=0,
     )
+    
+    # Add states and provinces borders
+    states_provinces = cfeature.NaturalEarthFeature(
+        category='cultural',
+        name='admin_1_states_provinces_lines',
+        scale='50m',
+        facecolor='none')
+
+    ax.add_feature(states_provinces, edgecolor='gray')
+    
 
 
 # Subclass ConciseDateFormatter (modifies __init__() and set_axis() methods)


### PR DESCRIPTION
This PR adds in state and province boundaries, gridlines, and grid labels for geographic basemaps using cartopy. 