### PR TITLE
Speed up AGC with pandas.rolling

### DIFF
--- a/rtm/waveform.py
+++ b/rtm/waveform.py
@@ -245,14 +245,16 @@ def _agc(st, win_sec, method='gismo', method_exec='old'):
                 scale = []
                 for i in range(half_win_samp, tr.count() - half_win_samp):
                     # The window is centered on index i
-                    scale_max = np.abs(tr.data[i - half_win_samp:
-                                            i + half_win_samp]).max()
+                    scale_max = np.abs(tr.data[
+                        i - half_win_samp : i + half_win_samp]).max()
                     scale.append(scale_max)
+
             elif method_exec == 'new':
                 n_width = 2 * half_win_samp
                 scale = np.array(pd.DataFrame(np.abs(tr.data)).rolling(
                     n_width, min_periods=n_width, center=True).max())
                 scale = np.transpose(scale[~np.isnan(scale)])
+                scale = scale[:-1]
 
             # Fill out the ends of scale with its first/last values
             scale = np.hstack((np.ones(half_win_samp) * scale[0],

--- a/rtm/waveform.py
+++ b/rtm/waveform.py
@@ -241,15 +241,15 @@ def _agc(st, win_sec, method='gismo', method_exec='old'):
 
             half_win_samp = int(tr.stats.sampling_rate * win_sec / 2)
 
-            scale = []
             if method_exec == 'old':
+                scale = []
                 for i in range(half_win_samp, tr.count() - half_win_samp):
                     # The window is centered on index i
                     scale_max = np.abs(tr.data[i - half_win_samp:
                                             i + half_win_samp]).max()
                     scale.append(scale_max)
             elif method_exec == 'new':
-                n_width = 2 * half_win_samp + 1
+                n_width = 2 * half_win_samp
                 scale = np.array(pd.DataFrame(np.abs(tr.data)).rolling(
                     n_width, min_periods=n_width, center=True).max())
                 scale = np.transpose(scale[~np.isnan(scale)])


### PR DESCRIPTION
Hi, I was looking for a an AGC implemented in Python to apply to an `obspy.core.Stream` and your package came up as the first result. When I tried the AGC for longer streams (1 - 24 hours), I found that it gets quite slow so I looked a bit into how to speed it up. I tried a few things like convolution, but achieved the best speed up with `pandas.DataFrame.rolling` - for 24 hours of one 100 Hz trace, the speed up was up to x50, e.g., from ~4200 ms to 90 ms for `method='walker'`.

As I haven't used or thought about RTM much yet I don't know if that is in any way relevant for your implementation; but I thought it's best to share it. For now I kept an option to switch between old and new implementation so that they can be easily compared; and I put some extra code lines in the comments that show other implementations that were not as fast. If you do want to merge the implementation I can of course also clean that up.

Demonstration that implementations give the same result:
```python
import numpy as np
from obspy import read
from rtm.waveform import _agc

st = read()
st.detrend()

# True (though tiny floating point differences, apparently due to mean function)
np.allclose(_agc(st, win_sec=5, method='gismo', method_exec='new')[0].data,
            _agc(st, win_sec=5, method='gismo', method_exec='old')[0].data,
            rtol=1e-12, atol=1e-15)
# True (exact)
(_agc(st, win_sec=5, method='walker', method_exec='new') ==
_agc(st, win_sec=5, method='walker', method_exec='old'))
```