### PR TITLE
Ensure homogeneous UTM zone number in FDTD prep

### DIFF
--- a/rtm/travel_time.py
+++ b/rtm/travel_time.py
@@ -84,7 +84,7 @@ def prepare_fdtd_run(FDTD_DIR, FILENAME_ROOT, station, dem, H_MAX, TEMP, MAX_T,
     for i, sta in enumerate(station):
         try:
             staloc[i] = LOCAL_INFRA_COORDS[sta]
-            stautm[i] = utm.from_latlon(staloc[i][0], staloc[i][1])  # TODO: force_zone_number?
+            stautm[i] = utm.from_latlon(staloc[i][0], staloc[i][1], force_zone_number=dem.UTM['zone'])
             # find station x/y grid point closest to utm x/y
             staxyz_g[i] = [np.abs(dem.x.values-stautm[i][0]).argmin(),
                            np.abs(dem.y.values-stautm[i][1]).argmin(), staloc[i][2]]


### PR DESCRIPTION
This PR forces one UTM zone number for a given network, so as to avoid issues where deployments span multiple UTM zones. Closes #68 (see that issue for a good example of a multiple-UTM-zone-spanning deployment!).

Also see 0d100ea142fa4200579a21da8169eaeec42b7b20, which was a commit that fixed this for plotting.