### PR TITLE
Update Read the Docs config file to fix builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+
 python:
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
This PR makes a small tweak to the Read the Docs (RTD) config file so that things work again. More tweaks to the `.readthedocs.yml` may be needed, but we can't text that until we get the GitHub webhook set up again.

@davidfee5 — you'll need to follow [these instructions](https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html#manual-integration-setup) to set this up, as I don't have access to the settings for the _rtm_ repo. Please ping me once you've set this up and I'll be able to complete this PR.