### PR TITLE
NumPy & conda fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: rtm
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - cartopy
   - ipython

--- a/rtm/grid.py
+++ b/rtm/grid.py
@@ -505,7 +505,7 @@ def grid_search(processed_st, grid, time_method, starttime=None, endtime=None,
                 stk = np.sum(dtmp, axis=0)
 
             elif stack_method == 'product':
-                stk = np.product(dtmp, axis=0)
+                stk = np.prod(dtmp, axis=0)
 
             elif stack_method == 'semblance':
                 semb = []


### PR DESCRIPTION
This small PR fixes two issues.
1. A bug in the stack function related to deprecated `np.product()` — just changed to `np.prod()` and we're good here. This was an error, not a warning...
2. Removed `defaults` from the conda env file. We only use packages from `conda-forge`, and having `defaults` in there causes conda to look for packages on repo.anaconda.com, which is blocked by some firewalls (hint hint... USGS). tl;dr removing this ensures the environment builds from the open-source `conda-forge` channel only, which is desired.